### PR TITLE
Fix IOS-1220:  "Carousel" is tool type

### DIFF
--- a/Source/Pointzi/SHCarouselLayout.swift
+++ b/Source/Pointzi/SHCarouselLayout.swift
@@ -275,11 +275,11 @@ class SHCarouselLayout: PaperOnboardingDataSource, PaperOnboardingDelegate
                 }
                 else
                 {
-                    return nil
+                    return UIColor.clear
                 }
             }
         }
-        return nil
+        return UIColor.clear
     }
     
     private func sendFeedResult(for index: Int)


### PR DESCRIPTION
When carousel’s background not setup, use clear color so that it adopts whole tip’s background.