### PR TITLE
Fix IOS-1223:  Carousel: when carousel display and image download, sh…

### DIFF
--- a/Source/OnboardingContantView/Item/OnboardingContantViewItem.swift
+++ b/Source/OnboardingContantView/Item/OnboardingContantViewItem.swift
@@ -40,13 +40,16 @@ extension OnboardingContentViewItem {
         if (self.imageView?.image == nil) //if already has image, not need to check
         {
             //there is a image source for this item
-            if let sourceLength = self.imageSource?.lengthOfBytes(using: String.Encoding.utf8), sourceLength > 0 {
-                let imageSource = notification.userInfo!["source"]
-                //it's same image source, so set the image
-                if (self.imageSource?.compare(imageSource as! String) == ComparisonResult.orderedSame)
+            if let imageSource = self.imageSource
+            {
+                if (imageSource.lengthOfBytes(using: String.Encoding.utf8) > 0)
                 {
-                    DispatchQueue.main.async {
-                        self.imageView?.image = notification.userInfo!["image"] as? UIImage
+                    let imageSourceNotification = notification.userInfo!["source"] as! String
+                    if (imageSource.compare(imageSourceNotification) == ComparisonResult.orderedSame)
+                    {
+                        DispatchQueue.main.async {
+                            self.imageView?.image = notification.userInfo!["image"] as? UIImage
+                        }
                     }
                 }
             }

--- a/Source/PageView/Item/PageViewItem.swift
+++ b/Source/PageView/Item/PageViewItem.swift
@@ -50,13 +50,16 @@ extension PageViewItem {
         if (self.imageView?.image == nil) //if already has image, not need to check
         {
             //there is a image source for this item
-            if let sourceLength = self.imageSource?.lengthOfBytes(using: String.Encoding.utf8), sourceLength > 0 {
-                let imageSource = notification.userInfo!["source"]
-                //it's same image source, so set the image
-                if (self.imageSource?.compare(imageSource as! String) == ComparisonResult.orderedSame)
+            if let imageSource = self.imageSource
+            {
+                if (imageSource.lengthOfBytes(using: String.Encoding.utf8) > 0)
                 {
-                    DispatchQueue.main.async {
-                        self.imageView?.image = notification.userInfo!["image"] as? UIImage
+                    let imageSourceNotification = notification.userInfo!["source"] as! String
+                    if (imageSource.compare(imageSourceNotification) == ComparisonResult.orderedSame)
+                    {
+                        DispatchQueue.main.async {
+                            self.imageView?.image = notification.userInfo!["image"] as? UIImage
+                        }
                     }
                 }
             }


### PR DESCRIPTION
…ould display image

When carousel shows before image/icon download, it should be able to refresh the newly download image/icon.
Test:
To simulate this situation, add pseudo code in SHTipUtil.m
+ (void)prepareImageWithSource:(NSString *)imageSource
                  withCallback:(void (^)(UIImage * image, NSString *imageUrl, NSError *error))callback
{
    callback = [callback copy];
    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
    …

So the images are updated by SH_PrepareImage notification.