### PR TITLE
Fix IOS-1226:  IOS only shows one line content, hiding the rest as “……

### DIFF
--- a/Source/OnboardingContantView/Item/OnboardingContantViewItem.swift
+++ b/Source/OnboardingContantView/Item/OnboardingContantViewItem.swift
@@ -127,6 +127,7 @@ private extension OnboardingContentViewItem {
   func createTitleLabel(_ onView: UIView) -> UILabel {
     let label = Init(createLabel()) {
       $0.font = UIFont(name: "Nunito-Bold" , size: 36)
+      $0.numberOfLines = 0
     }
     onView.addSubview(label)
     
@@ -138,11 +139,12 @@ private extension OnboardingContentViewItem {
       return
     }
 
-    for attribute in [NSLayoutAttribute.centerX, NSLayoutAttribute.leading, NSLayoutAttribute.trailing] {
-      (onView, label) >>>- {
-        $0.attribute = attribute
-        return
-      }
+    for (attribute, constant) in [(NSLayoutAttribute.leading, 10), (NSLayoutAttribute.trailing, -10)] {
+        (onView, label) >>>- {
+            $0.attribute = attribute
+            $0.constant  = CGFloat(constant)
+            return
+        }
     }
     return label
   }


### PR DESCRIPTION
…” which is different from dashboard

Fix paper-onboarding sdk to let title label can line break.