### PR TITLE
Fix IOS-1232:  Carousel: bottom icons don't cause navigate.

### DIFF
--- a/Source/PageView/PageContainerView/PageContainer.swift
+++ b/Source/PageView/PageContainerView/PageContainer.swift
@@ -75,16 +75,21 @@ extension PageContrainer {
   
   fileprivate func createItems(_ count: Int, radius: CGFloat, selectedRadius: CGFloat) -> [PageViewItem] {
     var items = [PageViewItem]()
-    // create first item 
+    // create first item
+    var tag = 1
     var item = createItem(radius, selectedRadius: selectedRadius, isSelect: true)
+    item.tag = tag
+    
     addConstraintsToView(item, radius: selectedRadius)
     items.append(item)
     
     for _ in 1..<count {
+      tag += 1
       let nextItem = createItem(radius, selectedRadius: selectedRadius)
       addConstraintsToView(nextItem, leftItem: item, radius: radius)
       items.append(nextItem)
       item = nextItem
+      item.tag = tag
     }
     return items
   }

--- a/Source/PageView/PageView.swift
+++ b/Source/PageView/PageView.swift
@@ -24,7 +24,7 @@ class PageView: UIView {
   }
   
   fileprivate var containerX: NSLayoutConstraint?
-  fileprivate var containerView: PageContrainer?
+  var containerView: PageContrainer?
   
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -43,6 +43,19 @@ class PageView: UIView {
     super.init(coder: aDecoder)
     commonInit()
   }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard
+            let containerView = self.containerView,
+            let items = containerView.items
+            else { return nil }
+        for item in items {
+            let frame = item.frame.insetBy(dx: -10, dy: -10)
+            guard frame.contains(point) else { continue }
+            return item
+        }
+        return nil
+    }
 }
 
 // MARK: public

--- a/Source/PaperOnboarding.swift
+++ b/Source/PaperOnboarding.swift
@@ -171,6 +171,23 @@ extension PaperOnboarding {
                                                           bottomConstant: pageViewBottomConstant * -1 - pageViewSelectedRadius)
     pageView = createPageView()
     gestureControl = GestureControl(view: self, delegate: self)
+    
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapAction))
+    addGestureRecognizer(tapGesture)
+  }
+  
+  @objc fileprivate func tapAction(_ sender: UITapGestureRecognizer) {
+    guard
+      let pageView = self.pageView,
+      let pageControl = pageView.containerView
+      else { return }
+    let touchLocation = sender.location(in: self)
+    let convertedLocation = pageControl.convert(touchLocation, from: self)
+    guard let pageItem = pageView.hitTest(convertedLocation, with: nil) else { return }
+    let index = pageItem.tag - 1
+    guard index != currentIndex else { return }
+    currentIndex(index, animated: true)
+    (delegate as? PaperOnboardingDelegate)?.onboardingWillTransitonToIndex(index)
   }
   
   fileprivate func createPageView() -> PageView {


### PR DESCRIPTION
Add tap gesture so that click icon button can navigate through carousel.